### PR TITLE
TECH-3837 Increased timeout for production

### DIFF
--- a/deploy/values.yml
+++ b/deploy/values.yml
@@ -76,13 +76,13 @@ livenessProbe:
     port: ${PORT}
   initialDelaySeconds: 5
   periodSeconds: 30
-  timeoutSeconds: 10
+  timeoutSeconds: 60
 readinessProbe:
   httpGet:
     port: ${PORT}
   initialDelaySeconds: 5
   periodSeconds: 30
-  timeoutSeconds: 10
+  timeoutSeconds: 60
 
 autoscaling:
   enabled: true


### PR DESCRIPTION
Staging pods were bouncing due to liveliness probe failing. Gave the pod and app a little more time to get ready, increased timeouts in production branch as well.
