### PR TITLE
feat: update cpu request from 200m to 250m for hpa

### DIFF
--- a/deploy/values.yml
+++ b/deploy/values.yml
@@ -40,7 +40,7 @@ resources:
   limits:
     memory: 500Mi
   requests:
-    cpu: 200m
+    cpu: 250m
     memory: 220Mi
 
 env:


### PR DESCRIPTION
## Ticket
Fusion hpa maxedout

## Description
This is to solve the hpa maxedout issue for fusion by bumping up the cpu request.
Codify the changes of the fix for the incident.

## What solved

- Bump the cpu request bump to handle the cpu usage increase

## Checklist:

~~- [ ] I have performed a self-review of my own code~~
~~- [ ] I have performed a self-review of my own chromatic changes~~
~~- [ ] I have commented on my code, particularly in hard-to-understand areas~~
~~- [ ] I have checked my code and corrected any misspellings~~
~~- [ ] I have removed any unnecessary console messages~~
~~- [ ] I have removed any commented code~~
~~- [ ] I have checked that there are no buggy stories in Storybook~~

## Screenshots (if apply)
<img width="977" height="280" alt="image" src="https://github.com/user-attachments/assets/bf6a68ce-3b55-43e0-8d5a-50d01e3559fd" />
